### PR TITLE
Add Builder Whitelist & Output Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,31 @@
-# cs2-dumper
 
+# cs2-dumper
 External offsets/interfaces dumper for Counter-Strike: 2, written in Rust.
 
+  
 # Generated Files
 
 Generated files are stored in the `generated` directory.
 
 📂 [Pre-generated Files](./generated)
 
-# Running Tests
+# Running The Application
+ Within CMD run:
+ `cs2_dumper --argument value --argument...`
 
-`cargo test -- --nocapture`
+## Available Arguments
+| Argument | Type | Description | Default Value | Required
+|--|--|--|--|--|
+| interfaces | bool | Dump Interfaces | True | [] |
+| offsets | bool | Dump Offsets | True | [] |
+| schemas | bool | Dump Schemas | True | [] |
+| dbuilders | String | Comma Separated String **without spaces** specifying the output file formats. Available Builders: [JSON, CPP, CSharp, Python, Rust] | Blank (All) | [] |
+| path | String | Folder name for dumped assets | True | [x] |
+| interfaces | bool | Dump Interfaces | True | [] |
+  
 
 # License
+
+  
 
 Please refer to the [LICENSE](./LICENSE) file for more details.

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ Generated files are stored in the `generated` directory.
 ## Available Arguments
 | Argument | Type | Description | Default Value | Required
 |--|--|--|--|--|
-| interfaces | bool | Dump Interfaces | True | [] |
-| offsets | bool | Dump Offsets | True | [] |
-| schemas | bool | Dump Schemas | True | [] |
-| dbuilders | String | Comma Separated String **without spaces** specifying the output file formats. Available Builders: [JSON, CPP, CSharp, Python, Rust] | Blank (All) | [] |
-| path | String | Folder name for dumped assets | True | [x] |
-| interfaces | bool | Dump Interfaces | True | [] |
+| interfaces | bool | Dump Interfaces | True | :heavy_multiplication_x: |
+| offsets | bool | Dump Offsets | True | :heavy_multiplication_x: |
+| schemas | bool | Dump Schemas | True | :heavy_multiplication_x: |
+| dbuilders | String | Comma Separated String **without spaces** specifying the output file formats. Available Builders: [JSON, CPP, CSharp, Python, Rust] | Blank (All) | :heavy_multiplication_x: |
+| path | String | Folder name for dumped assets | True | :heavy_check_mark: |
+| interfaces | bool | Dump Interfaces | True | :heavy_multiplication_x: |
   
 
 # License

--- a/README.md
+++ b/README.md
@@ -2,16 +2,11 @@
 # cs2-dumper
 External offsets/interfaces dumper for Counter-Strike: 2, written in Rust.
 
-  
-# Generated Files
-
-Generated files are stored in the `generated` directory.
-
 📂 [Pre-generated Files](./generated)
 
 # Running The Application
  Within CMD run:
- `cs2_dumper --argument value --argument...`
+ `cs2_dumper --path generated`
 
 ## Available Arguments
 | Argument | Type | Description | Default Value | Required
@@ -20,8 +15,8 @@ Generated files are stored in the `generated` directory.
 | offsets | bool | Dump Offsets | True | :heavy_multiplication_x: |
 | schemas | bool | Dump Schemas | True | :heavy_multiplication_x: |
 | dbuilders | String | Comma Separated String **without spaces** specifying the output file formats. Available Builders: [JSON, CPP, CSharp, Python, Rust] | Blank (All) | :heavy_multiplication_x: |
-| path | String | Folder name for dumped assets | True | :heavy_check_mark: |
-| interfaces | bool | Dump Interfaces | True | :heavy_multiplication_x: |
+| path | String | Folder name for Generated Files| True | :heavy_check_mark: |
+| verbose | bool | Print Debug Logging | False | :heavy_multiplication_x: |
   
 
 # License

--- a/src/dumpers/interfaces.rs
+++ b/src/dumpers/interfaces.rs
@@ -9,7 +9,7 @@ use crate::sdk::InterfaceReg;
 
 use super::{generate_files, Entries};
 
-pub fn dump_interfaces(builders: &mut Vec<FileBuilderEnum>, process: &Process) -> Result<()> {
+pub fn dump_interfaces(builders: &mut Vec<FileBuilderEnum>, process: &Process, path: &String) -> Result<()> {
     let mut entries = Entries::new();
 
     for module_name in process
@@ -63,7 +63,7 @@ pub fn dump_interfaces(builders: &mut Vec<FileBuilderEnum>, process: &Process) -
         }
     }
 
-    generate_files(builders, &entries, "interfaces")?;
+    generate_files(builders, &entries, "interfaces", &&path)?;
 
     Ok(())
 }

--- a/src/dumpers/mod.rs
+++ b/src/dumpers/mod.rs
@@ -6,7 +6,8 @@ use anyhow::Result;
 
 use chrono::Utc;
 
-use crate::builder::{FileBuilder, FileBuilderEnum};
+
+use crate::{builder::{FileBuilder, FileBuilderEnum}, main};
 
 pub use interfaces::dump_interfaces;
 pub use offsets::dump_offsets;
@@ -39,12 +40,13 @@ pub fn generate_file(
     builder: &mut FileBuilderEnum,
     entries: &Entries,
     file_name: &str,
+    path: &&String,
 ) -> Result<()> {
     if entries.is_empty() {
         return Ok(());
     }
 
-    let file_path = format!("generated/{}.{}", file_name, builder.extension());
+    let file_path = format!("{}/{}.{}", path, file_name, builder.extension());
 
     let mut file = File::create(file_path)?;
 
@@ -77,10 +79,11 @@ pub fn generate_files(
     builders: &mut [FileBuilderEnum],
     entries: &Entries,
     file_name: &str,
+    path: &&String,
 ) -> Result<()> {
     builders
         .iter_mut()
-        .try_for_each(|builder| generate_file(builder, entries, file_name))
+        .try_for_each(|builder| generate_file(builder, entries, file_name, &&path))
 }
 
 /// Writes the banner to the given file.

--- a/src/dumpers/offsets.rs
+++ b/src/dumpers/offsets.rs
@@ -117,7 +117,7 @@ mod tests {
     }
 }
 
-pub fn dump_offsets(builders: &mut Vec<FileBuilderEnum>, process: &Process) -> Result<()> {
+pub fn dump_offsets(builders: &mut Vec<FileBuilderEnum>, process: &Process, path: &String) -> Result<()> {
     let file = File::open("config.json")?;
 
     let config: Config = serde_json::from_reader(file)?;
@@ -205,7 +205,7 @@ pub fn dump_offsets(builders: &mut Vec<FileBuilderEnum>, process: &Process) -> R
         });
     }
 
-    generate_files(builders, &entries, "offsets")?;
+    generate_files(builders, &entries, "offsets", &path)?;
 
     Ok(())
 }

--- a/src/dumpers/schemas.rs
+++ b/src/dumpers/schemas.rs
@@ -7,7 +7,7 @@ use crate::sdk::SchemaSystem;
 
 use super::{generate_files, Entries};
 
-pub fn dump_schemas(builders: &mut Vec<FileBuilderEnum>, process: &Process) -> Result<()> {
+pub fn dump_schemas(builders: &mut Vec<FileBuilderEnum>, process: &Process, path: &String) -> Result<()> {
     let schema_system = SchemaSystem::new(&process)?;
 
     for type_scope in schema_system.type_scopes()? {
@@ -44,7 +44,7 @@ pub fn dump_schemas(builders: &mut Vec<FileBuilderEnum>, process: &Process) -> R
             }
         }
 
-        generate_files(builders, &entries, &module_name)?;
+        generate_files(builders, &entries, &module_name, &&path)?;
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ mod remote;
 mod sdk;
 
 #[derive(Debug, Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(author, version, about)]
 struct Args {
     #[arg(short, long)]
     interfaces: bool,
@@ -33,7 +33,7 @@ struct Args {
     #[arg(short, long)]
     schemas: bool,
 
-    #[arg(short, long)]
+    #[arg(short, long, default_value = "all")]
     dbuilders: String,
 
     #[arg(short, long)]
@@ -74,7 +74,7 @@ fn main() -> Result<()> {
     let mut active_builders: Vec<FileBuilderEnum> = Vec::new();
 
 
-    if dbuilders.len() == 0 {
+    if dbuilders == "all" {
         active_builders = vec![
             FileBuilderEnum::CppFileBuilder(CppFileBuilder),
             FileBuilderEnum::CSharpFileBuilder(CSharpFileBuilder),


### PR DESCRIPTION
ADDED:
- Argument to specify only the builders we would like to use
- Argument to specify an output folder
- Table to readme.md

This is the first time in my life developing with rust, if anything is programmed crappily I'd be happy to change it. Figured I'd submit for those who might find these features helpful.