### PR TITLE
Include build number in generated files

### DIFF
--- a/generated/animationsystem.dll.cs
+++ b/generated/animationsystem.dll.cs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:56 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 public static class AimMatrixOpFixedSettings_t {

--- a/generated/animationsystem.dll.hpp
+++ b/generated/animationsystem.dll.hpp
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:56 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 #pragma once

--- a/generated/animationsystem.dll.py
+++ b/generated/animationsystem.dll.py
@@ -1,6 +1,6 @@
 '''
 Created using https://github.com/a2x/cs2-dumper
-Fri, 22 Dec 2023 03:14:56 +0000
+Sat, 30 Dec 2023 03:17:25 +0000
 '''
 
 class AimMatrixOpFixedSettings_t:

--- a/generated/animationsystem.dll.rs
+++ b/generated/animationsystem.dll.rs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:56 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 #![allow(non_snake_case, non_upper_case_globals)]

--- a/generated/client.dll.cs
+++ b/generated/client.dll.cs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:57 +0000
+ * Sat, 30 Dec 2023 03:17:26 +0000
  */
 
 public static class ActiveModelConfig_t {

--- a/generated/client.dll.hpp
+++ b/generated/client.dll.hpp
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:58 +0000
+ * Sat, 30 Dec 2023 03:17:26 +0000
  */
 
 #pragma once

--- a/generated/client.dll.py
+++ b/generated/client.dll.py
@@ -1,6 +1,6 @@
 '''
 Created using https://github.com/a2x/cs2-dumper
-Fri, 22 Dec 2023 03:14:58 +0000
+Sat, 30 Dec 2023 03:17:26 +0000
 '''
 
 class ActiveModelConfig_t:

--- a/generated/client.dll.rs
+++ b/generated/client.dll.rs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:58 +0000
+ * Sat, 30 Dec 2023 03:17:26 +0000
  */
 
 #![allow(non_snake_case, non_upper_case_globals)]

--- a/generated/engine2.dll.cs
+++ b/generated/engine2.dll.cs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:56 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 public static class CEmptyEntityInstance {

--- a/generated/engine2.dll.hpp
+++ b/generated/engine2.dll.hpp
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:56 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 #pragma once

--- a/generated/engine2.dll.py
+++ b/generated/engine2.dll.py
@@ -1,6 +1,6 @@
 '''
 Created using https://github.com/a2x/cs2-dumper
-Fri, 22 Dec 2023 03:14:56 +0000
+Sat, 30 Dec 2023 03:17:25 +0000
 '''
 
 class CEmptyEntityInstance:

--- a/generated/engine2.dll.rs
+++ b/generated/engine2.dll.rs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:56 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 #![allow(non_snake_case, non_upper_case_globals)]

--- a/generated/host.dll.cs
+++ b/generated/host.dll.cs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:58 +0000
+ * Sat, 30 Dec 2023 03:17:26 +0000
  */
 
 public static class CAnimScriptBase {

--- a/generated/host.dll.hpp
+++ b/generated/host.dll.hpp
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:58 +0000
+ * Sat, 30 Dec 2023 03:17:26 +0000
  */
 
 #pragma once

--- a/generated/host.dll.py
+++ b/generated/host.dll.py
@@ -1,6 +1,6 @@
 '''
 Created using https://github.com/a2x/cs2-dumper
-Fri, 22 Dec 2023 03:14:58 +0000
+Sat, 30 Dec 2023 03:17:26 +0000
 '''
 
 class CAnimScriptBase:

--- a/generated/host.dll.rs
+++ b/generated/host.dll.rs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:58 +0000
+ * Sat, 30 Dec 2023 03:17:26 +0000
  */
 
 #![allow(non_snake_case, non_upper_case_globals)]

--- a/generated/interfaces.cs
+++ b/generated/interfaces.cs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:58 +0000
+ * Sat, 30 Dec 2023 03:17:26 +0000
  */
 
 public static class animationsystem_dll { // animationsystem.dll

--- a/generated/interfaces.hpp
+++ b/generated/interfaces.hpp
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:58 +0000
+ * Sat, 30 Dec 2023 03:17:26 +0000
  */
 
 #pragma once

--- a/generated/interfaces.py
+++ b/generated/interfaces.py
@@ -1,6 +1,6 @@
 '''
 Created using https://github.com/a2x/cs2-dumper
-Fri, 22 Dec 2023 03:14:58 +0000
+Sat, 30 Dec 2023 03:17:26 +0000
 '''
 
 class animationsystem_dll: # animationsystem.dll

--- a/generated/interfaces.rs
+++ b/generated/interfaces.rs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:58 +0000
+ * Sat, 30 Dec 2023 03:17:26 +0000
  */
 
 #![allow(non_snake_case, non_upper_case_globals)]

--- a/generated/materialsystem2.dll.cs
+++ b/generated/materialsystem2.dll.cs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:56 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 public static class MaterialParamBuffer_t { // MaterialParam_t

--- a/generated/materialsystem2.dll.hpp
+++ b/generated/materialsystem2.dll.hpp
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:56 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 #pragma once

--- a/generated/materialsystem2.dll.py
+++ b/generated/materialsystem2.dll.py
@@ -1,6 +1,6 @@
 '''
 Created using https://github.com/a2x/cs2-dumper
-Fri, 22 Dec 2023 03:14:56 +0000
+Sat, 30 Dec 2023 03:17:25 +0000
 '''
 
 class MaterialParamBuffer_t: # MaterialParam_t

--- a/generated/materialsystem2.dll.rs
+++ b/generated/materialsystem2.dll.rs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:56 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 #![allow(non_snake_case, non_upper_case_globals)]

--- a/generated/networksystem.dll.cs
+++ b/generated/networksystem.dll.cs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:56 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 public static class ChangeAccessorFieldPathIndex_t {

--- a/generated/networksystem.dll.hpp
+++ b/generated/networksystem.dll.hpp
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:56 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 #pragma once

--- a/generated/networksystem.dll.py
+++ b/generated/networksystem.dll.py
@@ -1,6 +1,6 @@
 '''
 Created using https://github.com/a2x/cs2-dumper
-Fri, 22 Dec 2023 03:14:56 +0000
+Sat, 30 Dec 2023 03:17:25 +0000
 '''
 
 class ChangeAccessorFieldPathIndex_t:

--- a/generated/networksystem.dll.rs
+++ b/generated/networksystem.dll.rs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:56 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 #![allow(non_snake_case, non_upper_case_globals)]

--- a/generated/offsets.cs
+++ b/generated/offsets.cs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:15:14 +0000
+ * Sat, 30 Dec 2023 03:17:26 +0000
  */
 
 public static class client_dll { // client.dll
@@ -38,6 +38,10 @@ public static class engine2_dll { // engine2.dll
     public const nint dwNetworkGameClient_signOnState = 0x240;
     public const nint dwWindowHeight = 0x596E1C;
     public const nint dwWindowWidth = 0x596E18;
+}
+
+public static class game_info { // Some additional information about the game at dump time
+    public const nint buildNumber = 0x369F; // Game build number
 }
 
 public static class inputsystem_dll { // inputsystem.dll

--- a/generated/offsets.hpp
+++ b/generated/offsets.hpp
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:15:14 +0000
+ * Sat, 30 Dec 2023 03:17:26 +0000
  */
 
 #pragma once
@@ -42,6 +42,10 @@ namespace engine2_dll { // engine2.dll
     constexpr std::ptrdiff_t dwNetworkGameClient_signOnState = 0x240;
     constexpr std::ptrdiff_t dwWindowHeight = 0x596E1C;
     constexpr std::ptrdiff_t dwWindowWidth = 0x596E18;
+}
+
+namespace game_info { // Some additional information about the game at dump time
+    constexpr std::ptrdiff_t buildNumber = 0x369F; // Game build number
 }
 
 namespace inputsystem_dll { // inputsystem.dll

--- a/generated/offsets.json
+++ b/generated/offsets.json
@@ -133,6 +133,15 @@
     },
     "comment": "engine2.dll"
   },
+  "game_info": {
+    "data": {
+      "buildNumber": {
+        "value": 13983,
+        "comment": "Game build number"
+      }
+    },
+    "comment": "Some additional information about the game at dump time"
+  },
   "inputsystem_dll": {
     "data": {
       "dwInputSystem": {

--- a/generated/offsets.py
+++ b/generated/offsets.py
@@ -1,6 +1,6 @@
 '''
 Created using https://github.com/a2x/cs2-dumper
-Fri, 22 Dec 2023 03:15:14 +0000
+Sat, 30 Dec 2023 03:17:26 +0000
 '''
 
 class client_dll: # client.dll
@@ -37,6 +37,9 @@ class engine2_dll: # engine2.dll
     dwNetworkGameClient_signOnState = 0x240
     dwWindowHeight = 0x596E1C
     dwWindowWidth = 0x596E18
+
+class game_info: # Some additional information about the game at dump time
+    buildNumber = 0x369F # Game build number
 
 class inputsystem_dll: # inputsystem.dll
     dwInputSystem = 0x35760

--- a/generated/offsets.rs
+++ b/generated/offsets.rs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:15:14 +0000
+ * Sat, 30 Dec 2023 03:17:26 +0000
  */
 
 #![allow(non_snake_case, non_upper_case_globals)]
@@ -40,6 +40,10 @@ pub mod engine2_dll { // engine2.dll
     pub const dwNetworkGameClient_signOnState: usize = 0x240;
     pub const dwWindowHeight: usize = 0x596E1C;
     pub const dwWindowWidth: usize = 0x596E18;
+}
+
+pub mod game_info { // Some additional information about the game at dump time
+    pub const buildNumber: usize = 0x369F; // Game build number
 }
 
 pub mod inputsystem_dll { // inputsystem.dll

--- a/generated/offsets.yaml
+++ b/generated/offsets.yaml
@@ -32,5 +32,7 @@ engine2_dll: # engine2.dll
     dwNetworkGameClient_signOnState: 576
     dwWindowHeight: 5860892
     dwWindowWidth: 5860888
+game_info: # Some additional information about the game at dump time
+    buildNumber: 13983 # Game build number
 inputsystem_dll: # inputsystem.dll
     dwInputSystem: 218976

--- a/generated/particles.dll.cs
+++ b/generated/particles.dll.cs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:57 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 public static class CBaseRendererSource2 { // CParticleFunctionRenderer

--- a/generated/particles.dll.hpp
+++ b/generated/particles.dll.hpp
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:57 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 #pragma once

--- a/generated/particles.dll.py
+++ b/generated/particles.dll.py
@@ -1,6 +1,6 @@
 '''
 Created using https://github.com/a2x/cs2-dumper
-Fri, 22 Dec 2023 03:14:57 +0000
+Sat, 30 Dec 2023 03:17:25 +0000
 '''
 
 class CBaseRendererSource2: # CParticleFunctionRenderer

--- a/generated/particles.dll.rs
+++ b/generated/particles.dll.rs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:57 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 #![allow(non_snake_case, non_upper_case_globals)]

--- a/generated/pulse_system.dll.cs
+++ b/generated/pulse_system.dll.cs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:57 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 public static class CBasePulseGraphInstance {

--- a/generated/pulse_system.dll.hpp
+++ b/generated/pulse_system.dll.hpp
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:57 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 #pragma once

--- a/generated/pulse_system.dll.py
+++ b/generated/pulse_system.dll.py
@@ -1,6 +1,6 @@
 '''
 Created using https://github.com/a2x/cs2-dumper
-Fri, 22 Dec 2023 03:14:57 +0000
+Sat, 30 Dec 2023 03:17:25 +0000
 '''
 
 class CBasePulseGraphInstance:

--- a/generated/pulse_system.dll.rs
+++ b/generated/pulse_system.dll.rs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:57 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 #![allow(non_snake_case, non_upper_case_globals)]

--- a/generated/rendersystemdx11.dll.cs
+++ b/generated/rendersystemdx11.dll.cs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:56 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 public static class RenderInputLayoutField_t {

--- a/generated/rendersystemdx11.dll.hpp
+++ b/generated/rendersystemdx11.dll.hpp
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:56 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 #pragma once

--- a/generated/rendersystemdx11.dll.py
+++ b/generated/rendersystemdx11.dll.py
@@ -1,6 +1,6 @@
 '''
 Created using https://github.com/a2x/cs2-dumper
-Fri, 22 Dec 2023 03:14:56 +0000
+Sat, 30 Dec 2023 03:17:25 +0000
 '''
 
 class RenderInputLayoutField_t:

--- a/generated/rendersystemdx11.dll.rs
+++ b/generated/rendersystemdx11.dll.rs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:56 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 #![allow(non_snake_case, non_upper_case_globals)]

--- a/generated/resourcesystem.dll.cs
+++ b/generated/resourcesystem.dll.cs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:56 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 public static class AABB_t {

--- a/generated/resourcesystem.dll.hpp
+++ b/generated/resourcesystem.dll.hpp
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:56 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 #pragma once

--- a/generated/resourcesystem.dll.py
+++ b/generated/resourcesystem.dll.py
@@ -1,6 +1,6 @@
 '''
 Created using https://github.com/a2x/cs2-dumper
-Fri, 22 Dec 2023 03:14:56 +0000
+Sat, 30 Dec 2023 03:17:25 +0000
 '''
 
 class AABB_t:

--- a/generated/resourcesystem.dll.rs
+++ b/generated/resourcesystem.dll.rs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:56 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 #![allow(non_snake_case, non_upper_case_globals)]

--- a/generated/scenesystem.dll.cs
+++ b/generated/scenesystem.dll.cs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:57 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 public static class CSSDSEndFrameViewInfo {

--- a/generated/scenesystem.dll.hpp
+++ b/generated/scenesystem.dll.hpp
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:57 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 #pragma once

--- a/generated/scenesystem.dll.py
+++ b/generated/scenesystem.dll.py
@@ -1,6 +1,6 @@
 '''
 Created using https://github.com/a2x/cs2-dumper
-Fri, 22 Dec 2023 03:14:57 +0000
+Sat, 30 Dec 2023 03:17:25 +0000
 '''
 
 class CSSDSEndFrameViewInfo:

--- a/generated/scenesystem.dll.rs
+++ b/generated/scenesystem.dll.rs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:57 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 #![allow(non_snake_case, non_upper_case_globals)]

--- a/generated/schemasystem.dll.cs
+++ b/generated/schemasystem.dll.cs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:56 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 public static class CExampleSchemaVData_Monomorphic {

--- a/generated/schemasystem.dll.hpp
+++ b/generated/schemasystem.dll.hpp
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:56 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 #pragma once

--- a/generated/schemasystem.dll.py
+++ b/generated/schemasystem.dll.py
@@ -1,6 +1,6 @@
 '''
 Created using https://github.com/a2x/cs2-dumper
-Fri, 22 Dec 2023 03:14:56 +0000
+Sat, 30 Dec 2023 03:17:25 +0000
 '''
 
 class CExampleSchemaVData_Monomorphic:

--- a/generated/schemasystem.dll.rs
+++ b/generated/schemasystem.dll.rs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:56 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 #![allow(non_snake_case, non_upper_case_globals)]

--- a/generated/server.dll.cs
+++ b/generated/server.dll.cs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:57 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 public static class ActiveModelConfig_t {

--- a/generated/server.dll.hpp
+++ b/generated/server.dll.hpp
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:57 +0000
+ * Sat, 30 Dec 2023 03:17:26 +0000
  */
 
 #pragma once

--- a/generated/server.dll.py
+++ b/generated/server.dll.py
@@ -1,6 +1,6 @@
 '''
 Created using https://github.com/a2x/cs2-dumper
-Fri, 22 Dec 2023 03:14:57 +0000
+Sat, 30 Dec 2023 03:17:26 +0000
 '''
 
 class ActiveModelConfig_t:

--- a/generated/server.dll.rs
+++ b/generated/server.dll.rs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:57 +0000
+ * Sat, 30 Dec 2023 03:17:26 +0000
  */
 
 #![allow(non_snake_case, non_upper_case_globals)]

--- a/generated/soundsystem.dll.cs
+++ b/generated/soundsystem.dll.cs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:56 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 public static class CDSPMixgroupModifier {

--- a/generated/soundsystem.dll.hpp
+++ b/generated/soundsystem.dll.hpp
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:56 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 #pragma once

--- a/generated/soundsystem.dll.py
+++ b/generated/soundsystem.dll.py
@@ -1,6 +1,6 @@
 '''
 Created using https://github.com/a2x/cs2-dumper
-Fri, 22 Dec 2023 03:14:57 +0000
+Sat, 30 Dec 2023 03:17:25 +0000
 '''
 
 class CDSPMixgroupModifier:

--- a/generated/soundsystem.dll.rs
+++ b/generated/soundsystem.dll.rs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:57 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 #![allow(non_snake_case, non_upper_case_globals)]

--- a/generated/vphysics2.dll.cs
+++ b/generated/vphysics2.dll.cs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:56 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 public static class CFeIndexedJiggleBone {

--- a/generated/vphysics2.dll.hpp
+++ b/generated/vphysics2.dll.hpp
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:56 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 #pragma once

--- a/generated/vphysics2.dll.py
+++ b/generated/vphysics2.dll.py
@@ -1,6 +1,6 @@
 '''
 Created using https://github.com/a2x/cs2-dumper
-Fri, 22 Dec 2023 03:14:56 +0000
+Sat, 30 Dec 2023 03:17:25 +0000
 '''
 
 class CFeIndexedJiggleBone:

--- a/generated/vphysics2.dll.rs
+++ b/generated/vphysics2.dll.rs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:56 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 #![allow(non_snake_case, non_upper_case_globals)]

--- a/generated/worldrenderer.dll.cs
+++ b/generated/worldrenderer.dll.cs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:57 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 public static class AggregateLODSetup_t {

--- a/generated/worldrenderer.dll.hpp
+++ b/generated/worldrenderer.dll.hpp
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:57 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 #pragma once

--- a/generated/worldrenderer.dll.py
+++ b/generated/worldrenderer.dll.py
@@ -1,6 +1,6 @@
 '''
 Created using https://github.com/a2x/cs2-dumper
-Fri, 22 Dec 2023 03:14:57 +0000
+Sat, 30 Dec 2023 03:17:25 +0000
 '''
 
 class AggregateLODSetup_t:

--- a/generated/worldrenderer.dll.rs
+++ b/generated/worldrenderer.dll.rs
@@ -1,6 +1,6 @@
 /*
  * Created using https://github.com/a2x/cs2-dumper
- * Fri, 22 Dec 2023 03:14:57 +0000
+ * Sat, 30 Dec 2023 03:17:25 +0000
  */
 
 #![allow(non_snake_case, non_upper_case_globals)]

--- a/src/dumper/offsets.rs
+++ b/src/dumper/offsets.rs
@@ -111,6 +111,24 @@ pub fn dump_offsets(
             (signature.name, address.sub(module.base().0).0)
         };
 
+        if name == "dwBuildNumber" {
+            let build_number: u32 = process.read_memory(module.base() + value)?;
+            debug!("Game build number: <bright-yellow>{}</>", build_number);
+
+            let container = entries
+                .entry(String::from("game_info"))
+                .or_default();
+
+            container.comment = Some(String::from("Some additional information about the game at dump time"));
+
+            container.data.push(Entry {
+                name: String::from("buildNumber"),
+                value: build_number as usize,
+                comment: Some(String::from("Game build number")),
+                indent: Some(indent),
+            });
+        }
+
         let container = entries
             .entry(signature.module.replace(".", "_"))
             .or_default();


### PR DESCRIPTION
PR to address #45, which I have opened some days ago.
This change creates a new container in the offsets file called `game_info`.  
For now this container gets created when `dwBuildNumber` is being read, and is being populated with one entry.  
Said entry is the build number, at the time of the dumping process.  
If there will be any other "dump-time" variables added to the container in the future, the relevant code should probably be relocated.

Long story short, in the end it basically adds this to the offset files (Here in rust):
```rust
pub mod game_info { // Some additional information about the game at dump time
    pub const buildNumber: usize = 0x369F; // Game build number
}
```