### PR TITLE
Add token escaping for Rust output `r#use`

### DIFF
--- a/src/output/buttons.rs
+++ b/src/output/buttons.rs
@@ -78,11 +78,12 @@ impl CodeGen for Vec<Button> {
 
                 fmt.block("pub mod buttons", false, |fmt| {
                     for button in self {
-                        writeln!(
-                            fmt,
-                            "pub const {}: usize = {:#X};",
-                            button.name, button.value
-                        )?;
+                        let mut name = button.name.clone();
+                        if name == "use" {
+                            name = format!("r#{}", name);
+                        }
+
+                        writeln!(fmt, "pub const {}: usize = {:#X};", name, button.value)?;
                     }
 
                     Ok(())


### PR DESCRIPTION
In the generated [button.rs](https://github.com/a2x/cs2-dumper/blob/main/output/buttons.rs) the keyword `use` hasn't been escaped which makes it problematic to include the generated output to any software source code directly (at least for my [use case](https://github.com/Txreq/gaben/tree/master/src/sdk/offsets/generated)). That little check shouldn't hurt :D