### PR TITLE
add pattern for ``CSoundService`` and ``EngineViewData``

### DIFF
--- a/output/offsets.cs
+++ b/output/offsets.cs
@@ -1,5 +1,5 @@
 // Generated using https://github.com/a2x/cs2-dumper
-// 2024-05-03 00:11:19.220511700 UTC
+// 2024-05-03 14:01:03.443608 UTC
 
 namespace CS2Dumper.Offsets {
     // Module: client.dll
@@ -25,11 +25,13 @@ namespace CS2Dumper.Offsets {
     // Module: engine2.dll
     public static class Engine2Dll {
         public const nint dwBuildNumber = 0x518764;
+        public const nint dwEngineViewData = 0x5CD76C;
         public const nint dwNetworkGameClient = 0x517B08;
         public const nint dwNetworkGameClient_deltaTick = 0x258;
         public const nint dwNetworkGameClient_getLocalPlayer = 0xF0;
         public const nint dwNetworkGameClient_getMaxClients = 0x250;
         public const nint dwNetworkGameClient_signOnState = 0x240;
+        public const nint dwSoundService = 0x5CD6D0;
         public const nint dwWindowHeight = 0x5D109C;
         public const nint dwWindowWidth = 0x5D1098;
     }

--- a/output/offsets.hpp
+++ b/output/offsets.hpp
@@ -1,5 +1,5 @@
 // Generated using https://github.com/a2x/cs2-dumper
-// 2024-05-03 00:11:19.220511700 UTC
+// 2024-05-03 14:01:03.443608 UTC
 
 #pragma once
 
@@ -30,11 +30,13 @@ namespace cs2_dumper {
         // Module: engine2.dll
         namespace engine2_dll {
             constexpr std::ptrdiff_t dwBuildNumber = 0x518764;
+            constexpr std::ptrdiff_t dwEngineViewData = 0x5CD76C;
             constexpr std::ptrdiff_t dwNetworkGameClient = 0x517B08;
             constexpr std::ptrdiff_t dwNetworkGameClient_deltaTick = 0x258;
             constexpr std::ptrdiff_t dwNetworkGameClient_getLocalPlayer = 0xF0;
             constexpr std::ptrdiff_t dwNetworkGameClient_getMaxClients = 0x250;
             constexpr std::ptrdiff_t dwNetworkGameClient_signOnState = 0x240;
+            constexpr std::ptrdiff_t dwSoundService = 0x5CD6D0;
             constexpr std::ptrdiff_t dwWindowHeight = 0x5D109C;
             constexpr std::ptrdiff_t dwWindowWidth = 0x5D1098;
         }

--- a/output/offsets.json
+++ b/output/offsets.json
@@ -20,11 +20,13 @@
   },
   "engine2.dll": {
     "dwBuildNumber": 5343076,
+    "dwEngineViewData": 6084460,
     "dwNetworkGameClient": 5339912,
     "dwNetworkGameClient_deltaTick": 600,
     "dwNetworkGameClient_getLocalPlayer": 240,
     "dwNetworkGameClient_getMaxClients": 592,
     "dwNetworkGameClient_signOnState": 576,
+    "dwSoundService": 6084304,
     "dwWindowHeight": 6099100,
     "dwWindowWidth": 6099096
   },

--- a/output/offsets.rs
+++ b/output/offsets.rs
@@ -1,5 +1,5 @@
 // Generated using https://github.com/a2x/cs2-dumper
-// 2024-05-03 00:11:19.220511700 UTC
+// 2024-05-03 14:01:03.443608 UTC
 
 #![allow(non_upper_case_globals, unused)]
 
@@ -28,11 +28,13 @@ pub mod cs2_dumper {
         // Module: engine2.dll
         pub mod engine2_dll {
             pub const dwBuildNumber: usize = 0x518764;
+            pub const dwEngineViewData: usize = 0x5CD76C;
             pub const dwNetworkGameClient: usize = 0x517B08;
             pub const dwNetworkGameClient_deltaTick: usize = 0x258;
             pub const dwNetworkGameClient_getLocalPlayer: usize = 0xF0;
             pub const dwNetworkGameClient_getMaxClients: usize = 0x250;
             pub const dwNetworkGameClient_signOnState: usize = 0x240;
+            pub const dwSoundService: usize = 0x5CD6D0;
             pub const dwWindowHeight: usize = 0x5D109C;
             pub const dwWindowWidth: usize = 0x5D1098;
         }

--- a/src/analysis/offsets.rs
+++ b/src/analysis/offsets.rs
@@ -108,6 +108,9 @@ pattern_map! {
         "dwNetworkGameClient_signOnState" => pattern!("448b81u2?? 488d0d") => None,
         "dwWindowHeight" => pattern!("8b05${'} 8903") => None,
         "dwWindowWidth" => pattern!("8b05${'} 8907") => None,
+        "dwSoundService" => pattern!("488905${'} 4c8d4424? 488d05") => Some(|_view, map, rva| {
+            map.insert("dwEngineViewData".to_string(), rva + 0x9C);
+        }),
     },
     input_system => {
         "dwInputSystem" => pattern!("488905${'} 488d05") => None,


### PR DESCRIPTION
Camera Position and Angles (not ClientViewAngles) are contiguous. (Vec3,Vec3)
Struct that I use:
```
typedef struct EngineCamera
{
	Vector3 Position;
	Vector3 Rotation;
};
```
I've reduced this PR to only touch output->offsets files.