### PR TITLE
Fix C# source gen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.idea
 /.vscode
+/.vs
 /target
 Cargo.lock

--- a/src/output/interfaces.rs
+++ b/src/output/interfaces.rs
@@ -16,7 +16,11 @@ impl CodeWriter for InterfaceMap {
                     false,
                     |fmt| {
                         for (name, value) in ifaces {
-                            writeln!(fmt, "public const nint {} = {:#X};", name, value)?;
+                            if *value > i32::MAX as u64 {
+                                writeln!(fmt, "public static readonly nint {} = unchecked((nint){:#X});", name, value)?;
+                            } else {
+                                writeln!(fmt, "public const nint {} = {:#X};", name, value)?;
+                            };
                         }
 
                         Ok(())

--- a/src/output/schemas.rs
+++ b/src/output/schemas.rs
@@ -41,7 +41,13 @@ impl CodeWriter for SchemaMap {
                                         .members
                                         .iter()
                                         .map(|member| {
-                                            format!("{} = {:#X}", member.name, member.value)
+                                            let hex = format!("{:#X}", member.value);
+                                            let cast = if member.value == -1 {
+                                                format!("unchecked(({})-1)", type_name)
+                                            } else {
+                                                format!("{}", hex)
+                                            };
+                                            format!("{} = {}", member.name, cast)
                                         })
                                         .collect::<Vec<_>>()
                                         .join(",\n");

--- a/src/output/schemas.rs
+++ b/src/output/schemas.rs
@@ -41,13 +41,12 @@ impl CodeWriter for SchemaMap {
                                         .members
                                         .iter()
                                         .map(|member| {
-                                            let hex = format!("{:#X}", member.value);
-                                            let cast = if member.value == -1 {
-                                                format!("unchecked(({})-1)", type_name)
+                                            let hex = if member.value < 0 || member.value > i32::MAX as i64 {
+                                                format!("unchecked(({}){})", type_name, member.value)
                                             } else {
-                                                format!("{}", hex)
+                                                format!("{:#X}", member.value)
                                             };
-                                            format!("{} = {}", member.name, cast)
+                                            format!("{} = {}", member.name, hex)
                                         })
                                         .collect::<Vec<_>>()
                                         .join(",\n");


### PR DESCRIPTION
As described in #311, this PR makes the generated C# source files valid by writing unchecked casts for values larger than i32::MAX. This is needed because there is no guarantee that nints in C# can be 64 bits wide, although that's never going to be the case with CS2.

Tried and tested