### PR TITLE
feat(analysis): add dwSvCheats (client-side) offset

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,7 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,7 +5,6 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
-  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/src/analysis/offsets.rs
+++ b/src/analysis/offsets.rs
@@ -96,6 +96,7 @@ pattern_map! {
         }),
         "dwSensitivity" => pattern!("488d0d${[8]'} 660f6ecd") => None,
         "dwSensitivity_sensitivity" => pattern!("488d7eu1 480fbae0? 72? 85d2 490f4fff") => None,
+        "dwSvCheats" => pattern!("488b05${'} 0f28f0 4885c0 7442") => None,
         "dwViewMatrix" => pattern!("488d0d${'} 48c1e006") => None,
         "dwViewRender" => pattern!("488905${'} 488bc8 4885c0") => None,
         "dwWeaponC4" => pattern!("488b15${'} 488b5c24? ffc0 8905${} 488bc6 488934ea 80be") => None,

--- a/src/output/offsets.rs
+++ b/src/output/offsets.rs
@@ -15,8 +15,7 @@ impl CodeWriter for OffsetMap {
                     false,
                     |fmt| {
                         for (name, value) in offsets {
-                            write_comment(fmt, name)?;
-                            writeln!(fmt, "public const nint {} = {:#X};", name, value)?;
+                            writeln!(fmt, "public const nint {} = {:#X};{}", name, value, comment(name))?;
                         }
 
                         Ok(())
@@ -43,8 +42,7 @@ impl CodeWriter for OffsetMap {
                         false,
                         |fmt| {
                             for (name, value) in offsets {
-                                write_comment(fmt, name)?;
-                                writeln!(fmt, "constexpr std::ptrdiff_t {} = {:#X};", name, value)?;
+                                writeln!(fmt, "constexpr std::ptrdiff_t {} = {:#X};{}", name, value, comment(name))?;
                             }
 
                             Ok(())
@@ -74,8 +72,7 @@ impl CodeWriter for OffsetMap {
                         false,
                         |fmt| {
                             for (name, value) in offsets {
-                                write_comment(fmt, name)?;
-                                writeln!(fmt, "pub const {}: usize = {:#X};", name, value)?;
+                                writeln!(fmt, "pub const {}: usize = {:#X};{}", name, value, comment(name))?;
                             }
 
                             Ok(())
@@ -101,12 +98,12 @@ impl CodeWriter for OffsetMap {
                         true,
                         |fmt| {
                             for (name, value) in offsets {
-                                write_comment(fmt, name)?;
                                 writeln!(
                                     fmt,
-                                    "pub const {}: usize = {:#X};",
+                                    "pub const {}: usize = {:#X};{}",
                                     zig_ident(name),
-                                    value
+                                    value,
+                                    comment(name)
                                 )?;
                             }
 
@@ -121,10 +118,10 @@ impl CodeWriter for OffsetMap {
     }
 }
 
-fn write_comment(fmt: &mut Formatter<'_>, name: &str) -> fmt::Result {
+fn comment(name: &str) -> &'static str {
     if name == "dwSvCheats" {
-        writeln!(fmt, "// sv_cheats ConVar")?;
+        " // sv_cheats ConVar"
+    } else {
+        ""
     }
-
-    Ok(())
 }

--- a/src/output/offsets.rs
+++ b/src/output/offsets.rs
@@ -15,6 +15,7 @@ impl CodeWriter for OffsetMap {
                     false,
                     |fmt| {
                         for (name, value) in offsets {
+                            write_comment(fmt, name)?;
                             writeln!(fmt, "public const nint {} = {:#X};", name, value)?;
                         }
 
@@ -42,6 +43,7 @@ impl CodeWriter for OffsetMap {
                         false,
                         |fmt| {
                             for (name, value) in offsets {
+                                write_comment(fmt, name)?;
                                 writeln!(fmt, "constexpr std::ptrdiff_t {} = {:#X};", name, value)?;
                             }
 
@@ -72,6 +74,7 @@ impl CodeWriter for OffsetMap {
                         false,
                         |fmt| {
                             for (name, value) in offsets {
+                                write_comment(fmt, name)?;
                                 writeln!(fmt, "pub const {}: usize = {:#X};", name, value)?;
                             }
 
@@ -98,6 +101,7 @@ impl CodeWriter for OffsetMap {
                         true,
                         |fmt| {
                             for (name, value) in offsets {
+                                write_comment(fmt, name)?;
                                 writeln!(
                                     fmt,
                                     "pub const {}: usize = {:#X};",
@@ -115,4 +119,12 @@ impl CodeWriter for OffsetMap {
             })
         })
     }
+}
+
+fn write_comment(fmt: &mut Formatter<'_>, name: &str) -> fmt::Result {
+    if name == "dwSvCheats" {
+        writeln!(fmt, "// sv_cheats ConVar")?;
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
Yo. Added the dwSvCheats offset to the client module.

Valve might be lazy, but this local flag is still useful for a lot of client-side stuff. It allows you to bypass the cheat check for commands like thirdperson and other client variables that only check the local state.

Specs:
    Found it manually in CE.
    Added a solid pattern so it won't break after every tiny game update.
    Tested on the latest build, works perfectly.
Let's get merged this BAAAAAD BOY. Cheers.

<img width="827" height="777" alt="изображение" src="https://github.com/user-attachments/assets/8a8817e4-d7fa-4d8a-8d4e-36f52edf861d" /> (gregor)