### PR TITLE
source dwSoundSystem from interface scanner, drop broken patterns

### DIFF
--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -42,6 +42,8 @@ pub fn analyze_all<P: Process + MemoryView>(process: &mut P) -> Result<AnalysisR
 
     let offsets = analyze(process, offsets);
 
+    let offsets = merge_interfaces_into_offsets(offsets, &interfaces);
+
     info!(
         "found {} offsets across {} modules",
         offsets
@@ -73,6 +75,19 @@ pub fn analyze_all<P: Process + MemoryView>(process: &mut P) -> Result<AnalysisR
         offsets,
         schemas,
     })
+}
+
+fn merge_interfaces_into_offsets(mut offsets: OffsetMap, interfaces: &InterfaceMap) -> OffsetMap {
+    if let Some(iface_map) = interfaces.get("soundsystem.dll") {
+        if let Some(&rva) = iface_map.get("SoundSystem001") {
+            offsets
+                .entry("soundsystem.dll".to_string())
+                .or_default()
+                .insert("dwSoundSystem".to_string(), rva as u32);
+        }
+    }
+
+    offsets
 }
 
 fn analyze<P, F, T>(process: &mut P, f: F) -> T

--- a/src/analysis/offsets.rs
+++ b/src/analysis/offsets.rs
@@ -86,7 +86,6 @@ pattern_map! {
         "dwGlobalVars" => pattern!("488915${'} 488942") => None,
         "dwGlowManager" => pattern!("488b05${'} c3 cccccccccccccccc 8b41") => None,
         "dwLocalPlayerController" => pattern!("488b05${'} 4189be") => None,
-        "dwPlantedC4" => pattern!("488b15${'} 41ffc0 488d4c24? 448905[4]") => None,
         "dwPrediction" => pattern!("488d05${'} c3 cccccccccccccccc 405356 4154") => Some(|view, map, rva| {
             let mut save = [0; 2];
 
@@ -95,7 +94,6 @@ pattern_map! {
             }
         }),
         "dwSensitivity" => pattern!("488d0d${[8]'} 660f6ecd") => None,
-        "dwSensitivity_sensitivity" => pattern!("488d7eu1 480fbae0? 72? 85d2 490f4fff") => None,
         "dwViewMatrix" => pattern!("488d0d${'} 48c1e006") => None,
         "dwViewRender" => pattern!("488905${'} 488bc8 4885c0") => None,
         "dwWeaponC4" => pattern!("488b15${'} 488b5c24? ffc0 8905${} 488bc6 488934ea 80be") => None,
@@ -105,7 +103,6 @@ pattern_map! {
         "dwNetworkGameClient" => pattern!("48893d${'} ff87") => None,
         "dwNetworkGameClient_clientTickCount" => pattern!("8b81u4 c3 cccccccccccccccccc 8b81${} c3 cccccccccccccccccc 83b9") => None,
         "dwNetworkGameClient_deltaTick" => pattern!("4c8db7u4 4c897c24") => None,
-        "dwNetworkGameClient_isBackgroundMap" => pattern!("0fb681u4 c3 cccccccccccccccc 0fb681${} c3 cccccccccccccccc 4053") => None,
         "dwNetworkGameClient_localPlayer" => pattern!("428b94d3u4 5b 49ffe3 32c0 5b c3 cccccccccccccccc 4053") => None,
         "dwNetworkGameClient_maxClients" => pattern!("8b81u4 c3????????? 8b81[4] c3????????? 8b81") => None,
         "dwNetworkGameClient_serverTickCount" => pattern!("8b81u4 c3 cccccccccccccccccc 83b9") => None,
@@ -120,7 +117,6 @@ pattern_map! {
         "dwGameTypes" => pattern!("488d0d${'} ff90") => None,
     },
     soundsystem => {
-        "dwSoundSystem" => pattern!("488d05${'} c3 cccccccccccccccc 488915") => None,
         "dwSoundSystem_engineViewData" => pattern!("0f1147u1 0f104e? 0f118f") => None,
     },
 }


### PR DESCRIPTION
Removed the dwSoundSystem byte pattern since it is redundant with the SoundSystem001 interface already found by the interface scanner. Added a small merge step that copies it from the interface map into the offset map after scanning. Dropped the other three patterns (dwPlantedC4, dwSensitivity_sensitivity, dwNetworkGameClient_isBackgroundMap) because their signatures broke in the latest game update and need new byte patterns.