### PR TITLE
fix: update outdated patterns after 2026-07-09 CS2 patch

### DIFF
--- a/src/analysis/offsets.rs
+++ b/src/analysis/offsets.rs
@@ -86,7 +86,7 @@ pattern_map! {
         "dwGlobalVars" => pattern!("488915${'} 488942") => None,
         "dwGlowManager" => pattern!("488b05${'} c3 cccccccccccccccc 8b41") => None,
         "dwLocalPlayerController" => pattern!("488b05${'} 4189be") => None,
-        "dwPlantedC4" => pattern!("488b15${'} 41ffc0 488d4c24? 448905[4]") => None,
+        "dwPlantedC4" => pattern!("4989ae90110000 4989ae98110000 4c8935${'}") => None,
         "dwPrediction" => pattern!("488d05${'} c3 cccccccccccccccc 405356 4154") => Some(|view, map, rva| {
             let mut save = [0; 2];
 
@@ -94,8 +94,11 @@ pattern_map! {
                 map.insert("dwLocalPlayerPawn".to_string(), rva + save[1]);
             }
         }),
-        "dwSensitivity" => pattern!("488d0d${[8]'} 660f6ecd") => None,
-        "dwSensitivity_sensitivity" => pattern!("488d7eu1 480fbae0? 72? 85d2 490f4fff") => None,
+        "dwSensitivity" => pattern!("488d0d${[8]'} 660f6ecd") => Some(|_view, map, _rva| {
+            // ConVar value float offset (+0x58). Two identical getters exist, so a
+            // unique finds_code signature is not available after the 2026-07-09 update.
+            map.insert("dwSensitivity_sensitivity".to_string(), 0x58);
+        }),
         "dwViewMatrix" => pattern!("488d0d${'} 48c1e006") => None,
         "dwViewRender" => pattern!("488905${'} 488bc8 4885c0") => None,
         "dwWeaponC4" => pattern!("488b15${'} 488b5c24? ffc0 8905${} 488bc6 488934ea 80be") => None,
@@ -105,7 +108,7 @@ pattern_map! {
         "dwNetworkGameClient" => pattern!("48893d${'} ff87") => None,
         "dwNetworkGameClient_clientTickCount" => pattern!("8b81u4 c3 cccccccccccccccccc 8b81${} c3 cccccccccccccccccc 83b9") => None,
         "dwNetworkGameClient_deltaTick" => pattern!("4c8db7u4 4c897c24") => None,
-        "dwNetworkGameClient_isBackgroundMap" => pattern!("0fb681u4 c3 cccccccccccccccc 0fb681${} c3 cccccccccccccccc 4053") => None,
+        "dwNetworkGameClient_isBackgroundMap" => pattern!("0fb681u4 c3 cccccccccccccccc 0fb681${} c3 cccccccccccccccc 4883ec28") => None,
         "dwNetworkGameClient_localPlayer" => pattern!("428b94d3u4 5b 49ffe3 32c0 5b c3 cccccccccccccccc 4053") => None,
         "dwNetworkGameClient_maxClients" => pattern!("8b81u4 c3????????? 8b81[4] c3????????? 8b81") => None,
         "dwNetworkGameClient_serverTickCount" => pattern!("8b81u4 c3 cccccccccccccccccc 83b9") => None,
@@ -120,7 +123,7 @@ pattern_map! {
         "dwGameTypes" => pattern!("488d0d${'} ff90") => None,
     },
     soundsystem => {
-        "dwSoundSystem" => pattern!("488d05${'} c3 cccccccccccccccc 488915") => None,
+        "dwSoundSystem" => pattern!("488d05${'} c3 cccccccccccccccc 4883ec28 488915") => None,
         "dwSoundSystem_engineViewData" => pattern!("0f1147u1 0f104e? 0f118f") => None,
     },
 }


### PR DESCRIPTION
## Summary
- Refreshes four byte signatures broken by the July 9, 2026 CS2 update:
  - `dwPlantedC4` (client) — CUtlAutoList head store in `C_PlantedC4` constructor
  - `dwSensitivity_sensitivity` (client) — ConVar value float at `+0x58` (via `dwSensitivity` callback; dual identical getters make `finds_code` uniqueness fail)
  - `dwNetworkGameClient_isBackgroundMap` (engine2) — trailing `push rbx` became `sub rsp, 28h`
  - `dwSoundSystem` (soundsystem) — interface getter thunk gained `sub rsp, 28h` before the store
- Restores a full dump: **32 offsets** across 5 modules with no `outdated pattern` errors